### PR TITLE
Add year and date practice screens

### DIFF
--- a/whatday.html
+++ b/whatday.html
@@ -23,10 +23,12 @@
   <div class="game-container flex items-center justify-center min-h-full p-4">
     <!-- Overlay (start screen) -->
     <div id="overlay" class="fixed inset-0 bg-gray-900/60 flex items-center justify-center z-10">
-    <button id="startBtn" class="px-8 py-3 text-xl font-bold text-white bg-blue-600 hover:bg-blue-700 rounded-2xl shadow-lg">
-      Start Challenge
-    </button>
-  </div>
+      <div class="space-y-4">
+        <button id="startBtn" class="w-full px-8 py-3 text-xl font-bold text-white bg-blue-600 hover:bg-blue-700 rounded-2xl shadow-lg">Full Challenge</button>
+        <button id="yearBtn" class="w-full px-8 py-3 text-xl font-bold text-white bg-green-600 hover:bg-green-700 rounded-2xl shadow-lg">Practice Year</button>
+        <button id="dateBtn" class="w-full px-8 py-3 text-xl font-bold text-white bg-purple-600 hover:bg-purple-700 rounded-2xl shadow-lg">Practice Date</button>
+      </div>
+    </div>
 
   <!-- Main game card -->
   <div id="game" class="hidden bg-white shadow-2xl rounded-2xl p-4 sm:p-6 w-full max-w-md text-center select-none">
@@ -46,6 +48,26 @@
     <div id="summary" class="text-lg sm:text-xl font-bold min-h-[1.5rem] mb-4"></div>
 
     <button id="nextBtn" class="w-full bg-green-600 hover:bg-green-700 text-white py-2 rounded-xl">Next Date</button>
+  </div>
+
+  <!-- Year practice card -->
+  <div id="yearPractice" class="hidden bg-white shadow-2xl rounded-2xl p-4 sm:p-6 w-full max-w-md text-center select-none">
+    <h1 class="text-2xl sm:text-3xl font-bold mb-2">Year Code Practice</h1>
+    <div id="yearDisplay" class="text-3xl sm:text-4xl font-mono mb-3">--</div>
+    <p class="text-lg font-semibold mb-2">Guess Year Code</p>
+    <div id="yearGrid" class="grid grid-cols-7 gap-1.5 sm:gap-2 mb-3"></div>
+    <div id="yearFeedback" class="text-lg sm:text-xl font-semibold min-h-[1.5rem] mb-3"></div>
+    <button id="yearNext" class="w-full bg-green-600 hover:bg-green-700 text-white py-2 rounded-xl">Next Year</button>
+  </div>
+
+  <!-- Date practice card -->
+  <div id="datePractice" class="hidden bg-white shadow-2xl rounded-2xl p-4 sm:p-6 w-full max-w-md text-center select-none">
+    <h1 class="text-2xl sm:text-3xl font-bold mb-2">Date Value Practice</h1>
+    <div id="dateDisplay" class="text-3xl sm:text-4xl font-mono mb-3">--</div>
+    <p class="text-lg font-semibold mb-2">Guess Date Value</p>
+    <div id="dateGrid" class="grid grid-cols-7 gap-1.5 sm:gap-2 mb-3"></div>
+    <div id="dateFeedback" class="text-lg sm:text-xl font-semibold min-h-[1.5rem] mb-3"></div>
+    <button id="dateNext" class="w-full bg-green-600 hover:bg-green-700 text-white py-2 rounded-xl">Next Date</button>
   </div>
   </div>
 
@@ -78,7 +100,11 @@
     /* ===== DOM refs ===== */
     const overlay = document.getElementById('overlay');
     const startBtn = document.getElementById('startBtn');
+    const yearBtn  = document.getElementById('yearBtn');
+    const dateBtn  = document.getElementById('dateBtn');
     const gameCard = document.getElementById('game');
+    const yearCard = document.getElementById('yearPractice');
+    const dateCard = document.getElementById('datePractice');
 
     const dateEl = document.getElementById('date');
     const stepEl = document.getElementById('stepLabel');
@@ -91,6 +117,14 @@
     const numGrid = document.getElementById('numGrid');
     const wkGrid  = document.getElementById('wkGrid');
     const nextBtn = document.getElementById('nextBtn');
+    const yearGrid = document.getElementById('yearGrid');
+    const dateGrid = document.getElementById('dateGrid');
+    const yearDisplay = document.getElementById('yearDisplay');
+    const dateDisplay = document.getElementById('dateDisplay');
+    const yearFbEl = document.getElementById('yearFeedback');
+    const dateFbEl = document.getElementById('dateFeedback');
+    const yearNext = document.getElementById('yearNext');
+    const dateNext = document.getElementById('dateNext');
 
     /* ===== Create buttons ===== */
     [-3,-2,-1,0,1,2,3].forEach(v=>{
@@ -99,6 +133,14 @@
       b.dataset.val=v;
       b.textContent=fmt(v);
       numGrid.appendChild(b);
+      const y=document.createElement('button');
+      y.className='yearBtn bg-gray-200 rounded-lg py-1';
+      y.dataset.val=v; y.textContent=fmt(v);
+      yearGrid.appendChild(y);
+      const d=document.createElement('button');
+      d.className='dateBtn bg-gray-200 rounded-lg py-1';
+      d.dataset.val=v; d.textContent=fmt(v);
+      dateGrid.appendChild(d);
     });
     ['Thu','Fri','Sat','Sun','Mon','Tue','Wed'].forEach(dw=>{
       const b=document.createElement('button');
@@ -108,12 +150,16 @@
       wkGrid.appendChild(b);
     });
 
-    const numBtns=document.querySelectorAll('.numBtn');
-    const wkBtns =document.querySelectorAll('.wkBtn');
+    const numBtns = document.querySelectorAll('.numBtn');
+    const wkBtns  = document.querySelectorAll('.wkBtn');
+    const yearBtns= document.querySelectorAll('.yearBtn');
+    const dateBtns= document.querySelectorAll('.dateBtn');
     const setEnabled=(nodes,flag)=>nodes.forEach(n=>n.disabled=!flag);
 
     /* ===== Game state ===== */
     let state=null;
+    let yearState=null;
+    let dateState=null;
 
     const newRound=()=>{
       const year = Math.floor(Math.random()*200)+1900;  // Only 1900-2099
@@ -134,6 +180,22 @@
       wkGrid.classList.add('hidden');
       setEnabled(numBtns,true); setEnabled(wkBtns,false);
       render();
+    };
+
+    const newYearRound=()=>{
+      const year=Math.floor(Math.random()*200)+1900;
+      yearState={year,yc:yearCode(year%100),done:false};
+      yearDisplay.textContent=year;
+      yearFbEl.textContent='';
+      setEnabled(yearBtns,true);
+    };
+
+    const newDateRound=()=>{
+      const dt=DATE_TABLE[Math.floor(Math.random()*DATE_TABLE.length)];
+      dateState={label:dt.label,dv:dt.code,done:false};
+      dateDisplay.textContent=dt.label;
+      dateFbEl.textContent='';
+      setEnabled(dateBtns,true);
     };
 
     /* ===== Render ===== */
@@ -177,6 +239,24 @@
       render();
     });
 
+    yearGrid.addEventListener('click',e=>{
+      if(!e.target.classList.contains('yearBtn')||yearState.done) return;
+      const val=Number(e.target.dataset.val);
+      yearState.done=true;
+      yearFbEl.className='text-lg sm:text-xl font-semibold '+(val===yearState.yc?'text-green-600':'text-red-600');
+      yearFbEl.textContent= val===yearState.yc?'Year Code ✔':`Year Code ✖ ( ${fmt(yearState.yc)} )`;
+      setEnabled(yearBtns,false);
+    });
+
+    dateGrid.addEventListener('click',e=>{
+      if(!e.target.classList.contains('dateBtn')||dateState.done) return;
+      const val=Number(e.target.dataset.val);
+      dateState.done=true;
+      dateFbEl.className='text-lg sm:text-xl font-semibold '+(val===dateState.dv?'text-green-600':'text-red-600');
+      dateFbEl.textContent= val===dateState.dv?'Date Value ✔':`Date Value ✖ ( ${fmt(dateState.dv)} )`;
+      setEnabled(dateBtns,false);
+    });
+
     wkGrid.addEventListener('click',e=>{
       if(!e.target.classList.contains('wkBtn')||state.done) return;
       const picked=e.target.dataset.dw;
@@ -192,10 +272,36 @@
       if(!gameCard.classList.contains('hidden')) newRound();
     });
 
+    yearNext.addEventListener('click',()=>{
+      if(!yearCard.classList.contains('hidden')) newYearRound();
+    });
+
+    dateNext.addEventListener('click',()=>{
+      if(!dateCard.classList.contains('hidden')) newDateRound();
+    });
+
     startBtn.addEventListener('click',()=>{
       overlay.classList.add('hidden');
       gameCard.classList.remove('hidden');
+      yearCard.classList.add('hidden');
+      dateCard.classList.add('hidden');
       newRound();
+    });
+
+    yearBtn.addEventListener('click',()=>{
+      overlay.classList.add('hidden');
+      gameCard.classList.add('hidden');
+      dateCard.classList.add('hidden');
+      yearCard.classList.remove('hidden');
+      newYearRound();
+    });
+
+    dateBtn.addEventListener('click',()=>{
+      overlay.classList.add('hidden');
+      gameCard.classList.add('hidden');
+      yearCard.classList.add('hidden');
+      dateCard.classList.remove('hidden');
+      newDateRound();
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- expand start screen with Full Challenge, Practice Year and Practice Date choices
- add Year Code and Date Value practice modes and handlers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b9e30578883299be9120390d16d9f